### PR TITLE
Clarify journey summary authorship in documentation rule

### DIFF
--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -8,6 +8,7 @@
 ## Journey Summaries
 
 - Location: `docs/summaries/NNN_summary_<topic>.md`
-- Writing style: first-person, humble tone, natural language
+- Writing style: first-person from the user's perspective, humble tone, natural language
+- Refer to Claude/Claude Code as "the AI" or "Claude", never "I" — the "I" in summaries is always the user
 - Proper punctuation — no dashes as sentence punctuation
 - Not AI-sounding


### PR DESCRIPTION
## Summary

- Updated `.claude/rules/documentation.md`: journey summaries use "I" for the user, refer to Claude as "the AI" or "Claude"

## Test plan

- N/A (rule definition only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)