### PR TITLE
Fix CI build order — build shared types before API

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "npm run dev:api & npm run dev:web",
     "dev:api": "npm run dev --workspace=apps/api",
     "dev:web": "npm run dev --workspace=apps/web",
-    "build": "npm run build --workspaces --if-present",
+    "build": "tsc -b && npm run build --workspace=apps/web",
     "test": "vitest run",
     "lint": "eslint .",
     "format": "prettier --write .",


### PR DESCRIPTION
## Summary

- Changed root `build` script from `npm run build --workspaces --if-present` to `tsc -b && npm run build --workspace=apps/web`
- `tsc -b` uses project references to build shared types first, then API (in dependency order)
- Vite builds the web frontend separately (it doesn't use `tsc`)

## Problem

CI build failed because workspaces ran in parallel — the API's `tsc` expected shared's `.d.ts` files to already exist, but shared hadn't built yet.

## Test plan

- `npm run build` completes locally
- CI build job should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)