### PR TITLE
Fix Docker job permissions for repo checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
     needs: [build]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
+      contents: read
       packages: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary

Added `contents: read` to the Docker job's permissions block. Job-level permissions override (not merge with) top-level permissions, so the Docker job lost read access when it only declared `packages: write`.

## Test plan

- CI Docker Build job should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)