### PR TITLE
Fix Docker builds — remove hoisted node_modules, build shared first

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -19,8 +19,6 @@ RUN npm run build --workspace=packages/shared && npm run build --workspace=apps/
 FROM base AS production
 ENV NODE_ENV=production
 COPY --from=deps /app/node_modules ./node_modules
-COPY --from=deps /app/packages/shared/node_modules ./packages/shared/node_modules
-COPY --from=deps /app/apps/api/node_modules ./apps/api/node_modules
 COPY --from=build /app/packages/shared/dist ./packages/shared/dist
 COPY --from=build /app/apps/api/dist ./apps/api/dist
 COPY packages/shared/package.json ./packages/shared/

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -13,7 +13,7 @@ FROM deps AS build
 COPY tsconfig.json ./
 COPY packages/shared/ ./packages/shared/
 COPY apps/web/ ./apps/web/
-RUN npm run build --workspace=apps/web
+RUN npm run build --workspace=packages/shared && npm run build --workspace=apps/web
 
 # Serve with nginx
 FROM nginx:alpine AS production


### PR DESCRIPTION
## Summary

- Removed `COPY` of workspace-specific `node_modules` from API Dockerfile (npm hoists to root)
- Added shared package build step before web build in web Dockerfile

## Problem

Docker build failed because it tried to copy `apps/api/node_modules` and `packages/shared/node_modules` which don't exist — npm workspaces hoists all dependencies to the root `node_modules`.

## Test plan

- CI Docker Build job should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)