### PR TITLE
Add git safety hook tests, fix .env.example false positive

### DIFF
--- a/.claude/hooks/__tests__/git-safety.test.ts
+++ b/.claude/hooks/__tests__/git-safety.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import { join } from 'path';
+
+const hookPath = join(__dirname, '..', 'git-safety.sh');
+
+function runHook(command: string): { stdout: string; exitCode: number } {
+  const input = JSON.stringify({ command });
+  try {
+    const stdout = execSync(`echo '${input}' | bash ${hookPath}`, {
+      encoding: 'utf8',
+      env: { ...process.env, PATH: process.env.PATH },
+    });
+    return { stdout, exitCode: 0 };
+  } catch (err) {
+    const error = err as { stdout: string; status: number };
+    return { stdout: error.stdout ?? '', exitCode: error.status };
+  }
+}
+
+describe('git-safety hook', () => {
+  describe('commit to main protection', () => {
+    it('blocks git commit on main branch', () => {
+      const result = runHook('git commit -m "test"');
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stdout).toContain('BLOCKED');
+      expect(result.stdout).toContain('Cannot commit directly to');
+    });
+
+    it('blocks git commit with flags before commit keyword', () => {
+      const result = runHook('git -c user.name=test commit -m "test"');
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stdout).toContain('BLOCKED');
+    });
+
+    it('allows git commit on feature branch', () => {
+      // This test only works if we're not on main — skip if we are
+      const branch = execSync('git branch --show-current', { encoding: 'utf8' }).trim();
+      if (branch === 'main' || branch === 'master') {
+        // We're on main, so the hook will block — this is expected
+        const result = runHook('git commit -m "test"');
+        expect(result.exitCode).toBe(2);
+        return;
+      }
+      const result = runHook('git commit -m "test"');
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe('force push protection', () => {
+    it('blocks git push --force', () => {
+      const result = runHook('git push --force origin main');
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stdout).toContain('BLOCKED');
+      expect(result.stdout).toContain('Force push');
+    });
+
+    it('blocks git push -f', () => {
+      const result = runHook('git push -f origin main');
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stdout).toContain('BLOCKED');
+    });
+
+    it('blocks --force-with-lease', () => {
+      const result = runHook('git push --force-with-lease origin main');
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stdout).toContain('BLOCKED');
+    });
+
+    it('allows normal git push', () => {
+      const result = runHook('git push origin feature/test');
+
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe('.env file protection', () => {
+    it('blocks staging .env', () => {
+      const result = runHook('git add .env');
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stdout).toContain('BLOCKED');
+      expect(result.stdout).toContain('.env');
+    });
+
+    it('blocks staging .env.local', () => {
+      const result = runHook('git add .env.local');
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stdout).toContain('BLOCKED');
+    });
+
+    it('blocks staging .env.production', () => {
+      const result = runHook('git add .env.production');
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stdout).toContain('BLOCKED');
+    });
+  });
+
+  describe('broad staging protection', () => {
+    it('blocks git add .', () => {
+      const result = runHook('git add .');
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stdout).toContain('BLOCKED');
+      expect(result.stdout).toContain('Broad staging');
+    });
+
+    it('blocks git add -A', () => {
+      const result = runHook('git add -A');
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stdout).toContain('BLOCKED');
+    });
+
+    it('blocks git add --all', () => {
+      const result = runHook('git add --all');
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stdout).toContain('BLOCKED');
+    });
+  });
+
+  describe('allowed commands', () => {
+    it('allows staging specific files', () => {
+      const result = runHook('git add apps/api/src/index.ts');
+
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('allows staging multiple specific files', () => {
+      const result = runHook('git add apps/api/src/index.ts packages/shared/src/index.ts');
+
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('allows non-git commands', () => {
+      const result = runHook('npm test');
+
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('allows git status', () => {
+      const result = runHook('git status');
+
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('allows git diff', () => {
+      const result = runHook('git diff');
+
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('allows staging .env.example', () => {
+      const result = runHook('git add .env.example');
+
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/.claude/hooks/git-safety.sh
+++ b/.claude/hooks/git-safety.sh
@@ -46,11 +46,11 @@ fi
 
 # Block staging .env files (explicit filename or wildcard staging)
 if echo "$command" | grep -qE '\bgit\b.*\badd\b'; then
-  if echo "$command" | grep -qE '\.env(\s|$|\.)'; then
+  if echo "$command" | grep -qE '\.env(\s|$|\.)' && ! echo "$command" | grep -qE '\.env\.example'; then
     echo "BLOCKED: Cannot stage .env files. They contain secrets and must not be committed."
     exit 2
   fi
-  if echo "$command" | grep -qE 'git add \.|git add -A|git add --all'; then
+  if echo "$command" | grep -qE 'git add \.(\s|$)|git add -A|git add --all'; then
     echo "BLOCKED: Broad staging commands are not allowed. Stage specific files instead."
     echo "Use: git add <file1> <file2> ..."
     exit 2

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
           include: ['apps/api/src/**/*.test.ts'],
         },
       },
+      {
+        test: {
+          name: 'hooks',
+          include: ['.claude/hooks/__tests__/*.test.ts'],
+        },
+      },
       'apps/web/vitest.config.ts',
     ],
   },


### PR DESCRIPTION
## Summary

- 19 automated tests for git-safety hook covering all safety checks
- Fixed `.env.example` false positive — hook now allows staging `.env.example` (template file with no secrets)
- Fixed `git add .` pattern matching too broadly (was catching `git add .env.example` as a substring)
- Added hooks test project to vitest workspace config

## Bugs found by tests

- `git add .env.example` was blocked because `.env.` matched the env pattern and `git add .` was a substring match
- Both fixed with more precise regex patterns

## Test plan

- `npm test` — 58 tests pass (22 API + 17 component + 19 hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)