### PR TITLE
feat: enable multi-arch Docker builds for Arm deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
@@ -81,6 +82,7 @@ jobs:
           context: .
           file: docker/Dockerfile.api
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository }}/api:latest
             ghcr.io/${{ github.repository }}/api:${{ github.sha }}
@@ -91,6 +93,7 @@ jobs:
           context: .
           file: docker/Dockerfile.web
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository }}/web:latest
             ghcr.io/${{ github.repository }}/web:${{ github.sha }}


### PR DESCRIPTION
## Summary

Closes #23

- Add QEMU setup step for cross-platform emulation
- Add `platforms: linux/amd64,linux/arm64` to both Docker build steps
- Required for deploying to Oracle Cloud A1 (aarch64) instance

## Test plan

- [ ] CI pipeline builds successfully for both architectures
- [ ] Multi-arch manifest exists in ghcr.io
- [ ] Images can be pulled and run on Arm instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)